### PR TITLE
Use hyperfoil_controller_host variable when starting controller

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,7 +127,7 @@
         -Dlog4j.configurationFile=file://{{ hyperfoil_log_config }}
         {% endif %}
         -Dio.hyperfoil.rootdir={{ hyperfoil_dir }}/workspace
-        -Dio.hyperfoil.controller.host={{ ansible_hostname }}
+        -Dio.hyperfoil.controller.host={{ hyperfoil_controller_host | default(ansible_hostname) }}
         -Dio.hyperfoil.controller.port={{ hyperfoil_controller_port }}
         {% if hyperfoil_jfr is defined and (hyperfoil_jfr | bool) %}
         -XX:+UnlockCommercialFeatures -XX:+FlightRecorder


### PR DESCRIPTION
Ensure the controller has the proper host name so agents can communicate back as needed.