### PR TITLE
Remove JVM flag for JFR enabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,7 +130,7 @@
         -Dio.hyperfoil.controller.host={{ hyperfoil_controller_host | default(ansible_hostname) }}
         -Dio.hyperfoil.controller.port={{ hyperfoil_controller_port }}
         {% if hyperfoil_jfr is defined and (hyperfoil_jfr | bool) %}
-        -XX:+UnlockCommercialFeatures -XX:+FlightRecorder
+        -XX:+FlightRecorder
         -XX:StartFlightRecording=compress=false,delay=10s,duration=24h,settings=profile,filename={{ hyperfoil_dir }}/hfc-{{ ansible_hostname }}.jfr
         {% endif %}
         {% if hyperfoil_trigger_url is defined %}


### PR DESCRIPTION
Since it was deprecated, the controller fails to start with:

```text
Unrecognized VM option 'UnlockCommercialFeatures'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

Where:

```text
$ java --version
openjdk 17.0.10 2024-01-16 LTS
OpenJDK Runtime Environment Corretto-17.0.10.8.1 (build 17.0.10+8-LTS)
OpenJDK 64-Bit Server VM Corretto-17.0.10.8.1 (build 17.0.10+8-LTS, mixed mode, sharing)
```

But I believe the flag was deprecated and removed back to 11, too.